### PR TITLE
Modal payment

### DIFF
--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -59,6 +59,31 @@ export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
               </button>
             </div>
           </div>
+
+          <div className="justify-end p-6 rounded-b" id="Response Informations">
+            {paymentResponse ? (
+              paymentResponse.success ? (
+                <>
+                  <p className="text-green-500">
+                    Payment success for skin #{skinId}
+                  </p>
+                  {paymentResponse.decode_me ? (
+                    <p>
+                      Les instructions pour le niveau suivant sont dans la
+                      réponse HTTP.<br/>Sauras-tu les trouver ?
+                    </p>
+                  ) : null}
+                </>
+              ) : (
+                <>
+                  <p className="text-red-500 w-full">
+                    Payment failed : {paymentResponse.status_code}
+                  </p>
+                  <p className="w-full">Message: {paymentResponse.message}</p>
+                </>
+              )
+            ) : null}
+          </div>
         </form>
       </div>
     </>

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -3,9 +3,10 @@ import { postPayment, PostPaymentBody } from "../utils/post-payment";
 
 interface PaymentModalProp {
   skinId: number;
+  setShowModal: (showModal: boolean) => void;
 }
 
-export function PaymentModal({ skinId }: PaymentModalProp) {
+export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
   const [cardSerial, setCardSerial] = useState<string>("");
 
   return (

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -20,40 +20,41 @@ export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
 
   return (
     <>
-      <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"></form>
+      <div className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
+        <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+          <h1 className="block text-gray-700 text-sm font-bold mb-2">
+            Skin #{skinId}
+          </h1>
+          <div className="mb-4">
+            <input
+              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+              id="card_serial"
+              type="text"
+              placeholder="Card Serial"
+              onChange={(inputCardSerial) => {
+                setCardSerial(inputCardSerial.target.value);
+              }}
+            />
+          </div>
 
-      <div className="mb-4">
-        <label
-          className="block text-gray-700 text-sm font-bold mb-2"
-          htmlFor="card_serial"
-        >
-          Card Serial
-          <input
-            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-            id="card_serial"
-            type="text"
-            placeholder="Card Serial"
-            onChange={(inputCardSerial) => {
-              setCardSerial(inputCardSerial.target.value);
-            }}
-          />
-        </label>
-      </div>
-
-      <div className="flex items-center justify-between">
-        <button
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
-          onClick={(event) => {
-            event.preventDefault();
-            const postPaymentBody: PostPaymentBody = {
-              card_serial: cardSerial,
-              skin_id: skinId,
-            };
-            postPayment(postPaymentBody);
-          }}
-        >
-          Submit
-        </button>
+          <div className="flex items-center justify-between">
+            <button
+              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full"
+              onClick={submitPayment}
+            >
+              Submit
+            </button>
+            <div className="flex items-center justify-end p-6 rounded-b">
+              <button
+                className="text-red-500 background-transparent font-bold uppercase text-sm ease-linear transition-all duration-150"
+                type="button"
+                onClick={() => setShowModal(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </form>
       </div>
     </>
   );

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,0 +1,13 @@
+import { useState } from "react";
+import { postPayment, PostPaymentBody } from "../utils/post-payment";
+
+interface PaymentModalProp {
+  skinId: number;
+}
+
+export function PaymentModal({ skinId }: PaymentModalProp) {
+  return (
+    <>
+    </>
+  );
+}

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -8,6 +8,7 @@ interface PaymentModalProp {
 export function PaymentModal({ skinId }: PaymentModalProp) {
   return (
     <>
+      <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"></form>
     </>
   );
 }

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -1,5 +1,9 @@
 import { useState } from "react";
-import { postPayment, PostPaymentBody } from "../utils/post-payment";
+import {
+  postPayment,
+  PostPaymentBody,
+  PostPaymentResponse,
+} from "../utils/post-payment";
 
 interface PaymentModalProp {
   skinId: number;
@@ -8,6 +12,7 @@ interface PaymentModalProp {
 
 export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
   const [cardSerial, setCardSerial] = useState<string>("");
+  const [paymentResponse, setPaymentResponse] = useState<PostPaymentResponse>();
 
   async function submitPayment(event: { preventDefault: () => void }) {
     event.preventDefault();
@@ -15,7 +20,7 @@ export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
       card_serial: cardSerial,
       skin_id: skinId,
     };
-    const responsePostPayment = await postPayment(postPaymentBody);
+    setPaymentResponse(await postPayment(postPaymentBody));
   }
 
   return (

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -9,6 +9,15 @@ interface PaymentModalProp {
 export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
   const [cardSerial, setCardSerial] = useState<string>("");
 
+  async function submitPayment(event: { preventDefault: () => void }) {
+    event.preventDefault();
+    const postPaymentBody: PostPaymentBody = {
+      card_serial: cardSerial,
+      skin_id: skinId,
+    };
+    const responsePostPayment = await postPayment(postPaymentBody);
+  }
+
   return (
     <>
       <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"></form>

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -26,65 +26,72 @@ export function PaymentModal({ skinId, setShowModal }: PaymentModalProp) {
   return (
     <>
       <div className="justify-center items-center flex overflow-x-hidden overflow-y-auto fixed inset-0 z-50 outline-none focus:outline-none">
-        <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
-          <h1 className="block text-gray-700 text-sm font-bold mb-2">
-            Skin #{skinId}
-          </h1>
-          <div className="mb-4">
-            <input
-              className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-              id="card_serial"
-              type="text"
-              placeholder="Card Serial"
-              onChange={(inputCardSerial) => {
-                setCardSerial(inputCardSerial.target.value);
-              }}
-            />
-          </div>
-
-          <div className="flex items-center justify-between">
-            <button
-              className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full"
-              onClick={submitPayment}
-            >
-              Submit
-            </button>
-            <div className="flex items-center justify-end p-6 rounded-b">
-              <button
-                className="text-red-500 background-transparent font-bold uppercase text-sm ease-linear transition-all duration-150"
-                type="button"
-                onClick={() => setShowModal(false)}
-              >
-                Close
-              </button>
+        <div className="w-4/5 md:w-2/5">
+          <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <h1 className="block text-gray-700 text-sm font-bold mb-2">
+              Skin #{skinId}
+            </h1>
+            <div className="mb-4">
+              <input
+                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                id="card_serial"
+                type="text"
+                placeholder="Card Serial"
+                onChange={(inputCardSerial) => {
+                  setCardSerial(inputCardSerial.target.value);
+                }}
+              />
             </div>
-          </div>
 
-          <div className="justify-end p-6 rounded-b" id="Response Informations">
-            {paymentResponse ? (
-              paymentResponse.success ? (
-                <>
-                  <p className="text-green-500">
-                    Payment success for skin #{skinId}
-                  </p>
-                  {paymentResponse.decode_me ? (
-                    <p>
-                      Les instructions pour le niveau suivant sont dans la
-                      réponse HTTP.<br/>Sauras-tu les trouver ?
+            <div className="flex items-center justify-between">
+              <button
+                className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full"
+                onClick={submitPayment}
+              >
+                Submit
+              </button>
+              <div className="flex items-center justify-end p-6 rounded-b">
+                <button
+                  className="text-red-500 background-transparent font-bold uppercase text-sm ease-linear transition-all duration-150"
+                  type="button"
+                  onClick={() => setShowModal(false)}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+
+            <div
+              className="justify-end p-6 rounded-b"
+              id="Response Informations"
+            >
+              {paymentResponse ? (
+                paymentResponse.success ? (
+                  <>
+                    <p className="text-green-500">
+                      Payment success for skin #{skinId}
                     </p>
-                  ) : null}
-                </>
-              ) : (
-                <>
-                  <p className="text-red-500 w-full">
-                    Payment failed : {paymentResponse.status_code}
-                  </p>
-                  <p className="w-full">Message: {paymentResponse.message}</p>
-                </>
-              )
-            ) : null}
-          </div>
-        </form>
+                    {paymentResponse.decode_me ? (
+                      <p>
+                        Les instructions pour le niveau suivant sont dans la
+                        réponse HTTP.
+                        <br />
+                        Sauras-tu les trouver ?
+                      </p>
+                    ) : null}
+                  </>
+                ) : (
+                  <>
+                    <p className="text-red-500 w-full">
+                      Payment failed : {paymentResponse.status_code}
+                    </p>
+                    <p className="w-full">Message: {paymentResponse.message}</p>
+                  </>
+                )
+              ) : null}
+            </div>
+          </form>
+        </div>
       </div>
     </>
   );

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -7,7 +7,7 @@ interface PaymentModalProp {
 
 export function PaymentModal({ skinId }: PaymentModalProp) {
   const [cardSerial, setCardSerial] = useState<string>("");
-  
+
   return (
     <>
       <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"></form>
@@ -28,6 +28,22 @@ export function PaymentModal({ skinId }: PaymentModalProp) {
             }}
           />
         </label>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <button
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+          onClick={(event) => {
+            event.preventDefault();
+            const postPaymentBody: PostPaymentBody = {
+              card_serial: cardSerial,
+              skin_id: skinId,
+            };
+            postPayment(postPaymentBody);
+          }}
+        >
+          Submit
+        </button>
       </div>
     </>
   );

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -6,9 +6,29 @@ interface PaymentModalProp {
 }
 
 export function PaymentModal({ skinId }: PaymentModalProp) {
+  const [cardSerial, setCardSerial] = useState<string>("");
+  
   return (
     <>
       <form className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4"></form>
+
+      <div className="mb-4">
+        <label
+          className="block text-gray-700 text-sm font-bold mb-2"
+          htmlFor="card_serial"
+        >
+          Card Serial
+          <input
+            className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+            id="card_serial"
+            type="text"
+            placeholder="Card Serial"
+            onChange={(inputCardSerial) => {
+              setCardSerial(inputCardSerial.target.value);
+            }}
+          />
+        </label>
+      </div>
     </>
   );
 }

--- a/src/components/Skins.tsx
+++ b/src/components/Skins.tsx
@@ -1,12 +1,25 @@
+import { useState } from "react";
 import {Skin} from "../types/skin.type";
 import {computeLevel} from "../utils/compute-level";
+import { PaymentModal } from "./PaymentModal";
 
 interface SkinsProp {
     skins: Skin[]
 }
 
-export const Skins = ({skins}: SkinsProp) => (
+export function Skins ({skins}: SkinsProp) {
+
+    const [showModal, setShowModal] = useState(false);
+    const [modalSkinId, setModalSkinId] = useState<number>(1);
+
+    function buySkin(skinId: number){
+        setModalSkinId(skinId);
+        setShowModal(true)
+    }
+
+    return (
     <>
+    {showModal ? (<PaymentModal skinId={modalSkinId} setShowModal={setShowModal}/>): null}
         {skins.map(skin => (
                 <li key={skin.id} className="py-3 sm:py-4">
                     <div className="flex items-center space-x-4">
@@ -21,11 +34,14 @@ export const Skins = ({skins}: SkinsProp) => (
                                 Level {computeLevel(skin)}
                             </p>
                         </div>
-                        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+                        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" 
+                                onClick={() => buySkin(skin.id) }>
                             ${skin.price}
                         </button>
                     </div>
                 </li>
             )
         )}
-    </>);
+    </>
+    )
+}

--- a/src/utils/post-payment.ts
+++ b/src/utils/post-payment.ts
@@ -13,10 +13,31 @@ export interface PostPaymentResponse {
   decode_me: boolean;
 }
 
-export const postPayment = async (body: PostPaymentBody) => {
-     await axios.post(`${environment.host}/api/payment`, body, {
-        headers: {
-            'x-auth-token': environment.playerToken
-        }
+export const postPayment = async (
+  body: PostPaymentBody
+): Promise<PostPaymentResponse> => {
+  return await axios
+    .post(`${environment.host}/api/payment`, body, {
+      headers: {
+        "x-auth-token": environment.playerToken,
+        "content-type": "application/json",
+        Accept: "application/json",
+      },
+    })
+    .then((response) => {
+      return {
+        success: true,
+        message: "Good Job !",
+        status_code: response.status,
+        decode_me: response?.headers?.["decode-me"],
+      };
+    })
+    .catch((error) => {
+      return {
+        success: false,
+        message: error.response.data.message,
+        status_code: error.response.status,
+        decode_me: false,
+      };
     });
-}
+};

--- a/src/utils/post-payment.ts
+++ b/src/utils/post-payment.ts
@@ -2,8 +2,15 @@ import axios from "axios";
 import { environment } from "./environment";
 
 export interface PostPaymentBody {
-    skin_id: number,
-    card_serial: string,
+  skin_id: number;
+  card_serial: string;
+}
+
+export interface PostPaymentResponse {
+  success: boolean;
+  message: string;
+  status_code: number;
+  decode_me: boolean;
 }
 
 export const postPayment = async (body: PostPaymentBody) => {

--- a/src/utils/post-payment.ts
+++ b/src/utils/post-payment.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import { environment } from "./environment";
+
+export interface PostPaymentBody {
+    skin_id: number,
+    card_serial: string,
+}
+
+export const postPayment = async (body: PostPaymentBody) => {
+     await axios.post(`${environment.host}/api/payment`, body, {
+        headers: {
+            'x-auth-token': environment.playerToken
+        }
+    });
+}


### PR DESCRIPTION
# Ticket
[https://www.notion.so/m33/ETQPlayer-j-ai-un-formulaire-pour-saisir-les-num-ros-de-c[…]qui-s-affiche-dans-une-modale-b945394d5e6d422cac7aa03e20a89705](https://www.notion.so/m33/ETQPlayer-j-ai-un-formulaire-pour-saisir-les-num-ros-de-carte-qui-s-affiche-dans-une-modale-b945394d5e6d422cac7aa03e20a89705)

# Warning
Pour tester ce ticket, il faut dabord valider le ticket https://github.com/sipios/siprip-api/pull/22

# Description
Ajouter une modale qui permet à l'utilisateur de faire une requete sur l'endpoint `payment` de l'API directement depuis le site

# Comment tester
*Prérequis : Se rendre sur la page http://localhost:5173/ et voir la liste des skins.*
- [ ]  Lorsqu’on clique sur le montant, une modale s’affiche
- [ ]  Dans la modale j’ai un champ text input pour saisir le numéro de carte
- [ ]  Dans la modale j’ai un bouton  `soumettre` qui effectue le paiement
- [ ]  Si dans la réponse du paiement j’ai un header `decode-me*` alors j’affiche le message `Les instructions pour le niveau suivant sont dans la réponse HTTP. Sauras-tu les trouver ?`
- [ ] Si la réponse est une erreur, je vois le code d'erreur et le message 

# Screenshots
<img width="904" alt="image" src="https://user-images.githubusercontent.com/125877968/229831167-167168bf-ab1f-4a66-9cc1-7b8a780e6ac3.png">

<img width="928" alt="image" src="https://user-images.githubusercontent.com/125877968/229831276-6a73218b-1ce9-42dc-a45d-80666ffdcbf6.png">

<img width="962" alt="image" src="https://user-images.githubusercontent.com/125877968/229831447-f5026c91-0c10-4274-ae55-75e0172b69ea.png">



